### PR TITLE
Enable SPI functionality in GraalVM native mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ To make testing simple, the extension provides the `HazelcastServerTestResource`
 ## Limitations (native mode)
 - Default Java serialization is not supported
 - User code deployment is not supported
+- Hazelcast SPI support is limited

--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ To make testing simple, the extension provides the `HazelcastServerTestResource`
 ## Limitations (native mode)
 - Default Java serialization is not supported
 - User code deployment is not supported
-- Hazelcast SPI support is limited
+- Hazelcast SPI support can be limited on OSGi

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
 
 
     <properties>
-        <quarkus.version>1.3.0.Final</quarkus.version>
-        <hazelcast.version>4.0</hazelcast.version>
+        <quarkus.version>1.3.2.Final</quarkus.version>
+        <hazelcast.version>4.0.1</hazelcast.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/ServiceLoaderUtils.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/ServiceLoaderUtils.java
@@ -1,6 +1,5 @@
 package io.quarkus.hazelcast.client.runtime.graal;
 
-import com.hazelcast.internal.util.ServiceLoader;
 import com.hazelcast.logging.ILogger;
 
 import java.io.BufferedReader;
@@ -17,7 +16,7 @@ final class ServiceLoaderUtils {
     private ServiceLoaderUtils() {
     }
 
-    /**
+    /*
      * Expanded version of {@link com.hazelcast.internal.util.ServiceLoader#parse(ServiceLoader.URLDefinition)
      * that's additionally parameterized with {@link ILogger} }
      */

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/ServiceLoaderUtils.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/ServiceLoaderUtils.java
@@ -1,5 +1,6 @@
 package io.quarkus.hazelcast.client.runtime.graal;
 
+import com.hazelcast.internal.util.ServiceLoader;
 import com.hazelcast.logging.ILogger;
 
 import java.io.BufferedReader;
@@ -16,6 +17,10 @@ final class ServiceLoaderUtils {
     private ServiceLoaderUtils() {
     }
 
+    /**
+     * Expanded version of {@link com.hazelcast.internal.util.ServiceLoader#parse(ServiceLoader.URLDefinition)
+     * that's additionally parameterized with {@link ILogger} }
+     */
     static Set<Target_ServiceDefinition> parse(URL url, ClassLoader classLoader, ILogger logger) {
         try {
             Set<Target_ServiceDefinition> names = new HashSet<>();

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/ServiceLoaderUtils.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/ServiceLoaderUtils.java
@@ -17,8 +17,8 @@ final class ServiceLoaderUtils {
     }
 
     /*
-     * Expanded version of {@link com.hazelcast.internal.util.ServiceLoader#parse(ServiceLoader.URLDefinition)
-     * that's additionally parameterized with {@link ILogger} }
+    Expanded version of {@link com.hazelcast.internal.util.ServiceLoader#parse(ServiceLoader.URLDefinition)
+    that's additionally parameterized with {@link ILogger} }
      */
     static Set<Target_ServiceDefinition> parse(URL url, ClassLoader classLoader, ILogger logger) {
         try {
@@ -49,5 +49,9 @@ final class ServiceLoaderUtils {
             logger.severe(e);
         }
         return Collections.emptySet();
+    }
+
+    static ClassLoader resolveClassloader(ClassLoader classLoader) {
+        return classLoader == null ? Thread.currentThread().getContextClassLoader() : classLoader;
     }
 }

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/ServiceLoaderUtils.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/ServiceLoaderUtils.java
@@ -1,0 +1,49 @@
+package io.quarkus.hazelcast.client.runtime.graal;
+
+import com.hazelcast.logging.ILogger;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.hazelcast.internal.nio.IOUtil.closeResource;
+
+final class ServiceLoaderUtils {
+    private ServiceLoaderUtils() {
+    }
+
+    static Set<Target_ServiceDefinition> parse(URL url, ClassLoader classLoader, ILogger logger) {
+        try {
+            Set<Target_ServiceDefinition> names = new HashSet<>();
+            BufferedReader r = null;
+            try {
+                r = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
+                while (true) {
+                    String line = r.readLine();
+                    if (line == null) {
+                        break;
+                    }
+                    int comment = line.indexOf('#');
+                    if (comment >= 0) {
+                        line = line.substring(0, comment);
+                    }
+                    String name = line.trim();
+                    if (name.length() == 0) {
+                        continue;
+                    }
+                    names.add(new Target_ServiceDefinition(name, classLoader));
+                }
+            } finally {
+                closeResource(r);
+            }
+            return names;
+        } catch (Exception e) {
+            logger.severe(e);
+        }
+        return Collections.emptySet();
+    }
+}

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_JCacheDetector.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_JCacheDetector.java
@@ -5,6 +5,9 @@ import com.hazelcast.logging.ILogger;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
+/*
+ * JCache is not supported under GraalVM, therefore JCache detection infrastructure can be removed.
+ */
 @TargetClass(JCacheDetector.class)
 public final class Target_JCacheDetector {
 
@@ -12,6 +15,7 @@ public final class Target_JCacheDetector {
     public static boolean isJCacheAvailable(ClassLoader classLoader) {
         return false;
     }
+
 
     @Substitute
     public static boolean isJCacheAvailable(ClassLoader classLoader, ILogger logger) {

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceDefinition.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceDefinition.java
@@ -1,0 +1,44 @@
+package io.quarkus.hazelcast.client.runtime.graal;
+
+import com.hazelcast.internal.util.ServiceLoader;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import java.util.function.BooleanSupplier;
+
+import static com.hazelcast.internal.util.Preconditions.isNotNull;
+
+@Substitute
+@TargetClass(className = "com.hazelcast.internal.util.ServiceLoader", innerClass = "ServiceDefinition")
+final class Target_ServiceDefinition {
+    private final String className;
+    private final ClassLoader classLoader;
+
+    public Target_ServiceDefinition(String className, ClassLoader classLoader) {
+        this.className = isNotNull(className, "className");
+        this.classLoader = isNotNull(classLoader, "classLoader");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Target_ServiceDefinition that = (Target_ServiceDefinition) o;
+        if (!classLoader.equals(that.classLoader)) {
+            return false;
+        }
+        return className.equals(that.className);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = className.hashCode();
+        result = 31 * result + classLoader.hashCode();
+        return result;
+    }
+}

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceDefinition.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceDefinition.java
@@ -1,10 +1,7 @@
 package io.quarkus.hazelcast.client.runtime.graal;
 
-import com.hazelcast.internal.util.ServiceLoader;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
-
-import java.util.function.BooleanSupplier;
 
 import static com.hazelcast.internal.util.Preconditions.isNotNull;
 

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceDefinition.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceDefinition.java
@@ -16,14 +16,6 @@ final class Target_ServiceDefinition {
         this.classLoader = isNotNull(classLoader, "classLoader");
     }
 
-    public String getClassName() {
-        return className;
-    }
-
-    public ClassLoader getClassLoader() {
-        return classLoader;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceDefinition.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceDefinition.java
@@ -16,6 +16,14 @@ final class Target_ServiceDefinition {
         this.classLoader = isNotNull(classLoader, "classLoader");
     }
 
+    public String getClassName() {
+        return className;
+    }
+
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceLoader.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceLoader.java
@@ -21,23 +21,23 @@ public final class Target_ServiceLoader {
     @Alias
     private static ILogger LOGGER;
 
-    /**
+    /*
      * Hazelcast SPI relies on the classpath presence of multiple _META-INF/services/com.foo.Bar_ files (for example, _com.hazelcast.spi.discovery.multicast.DiscoveryStrategyFactory_).
      *
      * However, the internal implementation of ServiceLoader doesn't play along with GraalVM's native images
      * since Substrate doesn't really feature a _normal_ classpath nor classloading but a mere _simulation_ of these.
      *
      * URLs to classpath resources located in different jars normally look like:
-     * ```
+     *
      * jar:file:/work/application/lib/com.hazelcast.hazelcast-4.0.1.jar!/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
      * jar:file:/work/application/lib/com.hazelcast.hazelcast-kubernetes-2.0.1.jar!/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
-     * ```
+     *
      *
      * but under Substrate, they become _resources_ and share the same URL (but `URL#openStream` leads to different content) which requires special handling:
-     * ```
+     *
      * resource:META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
      * resource:META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
-     * ```
+     *
      *
      * In order to make it work under GraalVM, we need to give up extra URL processing and don't enforce uniqueness for URLs, but for their content instead.
      */

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceLoader.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceLoader.java
@@ -9,11 +9,13 @@ import com.oracle.svm.core.annotate.TargetClass;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 
 import static io.quarkus.hazelcast.client.runtime.graal.ServiceLoaderUtils.parse;
+import static io.quarkus.hazelcast.client.runtime.graal.ServiceLoaderUtils.resolveClassloader;
 
 @TargetClass(ServiceLoader.class)
 public final class Target_ServiceLoader {
@@ -22,35 +24,36 @@ public final class Target_ServiceLoader {
     private static ILogger LOGGER;
 
     /*
-     * Hazelcast SPI relies on the classpath presence of multiple _META-INF/services/com.foo.Bar_ files (for example, _com.hazelcast.spi.discovery.multicast.DiscoveryStrategyFactory_).
-     *
-     * However, the internal implementation of ServiceLoader doesn't play along with GraalVM's native images
-     * since Substrate doesn't really feature a _normal_ classpath nor classloading but a mere _simulation_ of these.
-     *
-     * URLs to classpath resources located in different jars normally look like:
-     *
-     * jar:file:/work/application/lib/com.hazelcast.hazelcast-4.0.1.jar!/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
-     * jar:file:/work/application/lib/com.hazelcast.hazelcast-kubernetes-2.0.1.jar!/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
-     *
-     *
-     * but under Substrate, they become _resources_ and share the same URL (but `URL#openStream` leads to different content) which requires special handling:
-     *
-     * resource:META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
-     * resource:META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
-     *
-     *
-     * In order to make it work under GraalVM, we need to give up extra URL processing and don't enforce uniqueness for URLs, but for their content instead.
+     Hazelcast SPI relies on the classpath presence of multiple _META-INF/services/com.foo.Bar_ files (for example, _com.hazelcast.spi.discovery.multicast.DiscoveryStrategyFactory_).
+
+     However, the internal implementation of ServiceLoader doesn't play along with Substrate since
+     it doesn't really feature a _normal_ classpath nor classloading but a mere _simulation_ of these.
+
+     URLs to classpath resources located in different jars normally look like:
+
+     jar:file:/work/application/lib/com.hazelcast.hazelcast-4.0.1.jar!/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+     jar:file:/work/application/lib/com.hazelcast.hazelcast-kubernetes-2.0.1.jar!/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+
+     but under Substrate, they become _resources_ and share the same URL (but `URL#openStream` leads to different content) which requires special handling:
+
+     resource:META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+     resource:META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+
+     In order to make it work under GraalVM, we need to give up extra URL processing and don't enforce uniqueness for URLs, but for their content instead.
+     We need to make sure that we're properly handling system classloader represented as (null)
      */
     @Substitute
     private static Set<Target_ServiceDefinition> getServiceDefinitions(String factoryId, ClassLoader classLoader) {
+        ClassLoader actual = resolveClassloader(classLoader);
 
         Set<Target_ServiceDefinition> services = new HashSet<>();
 
         try {
-            Enumeration<URL> resources = classLoader.getResources("META-INF/services/" + factoryId);
+            Enumeration<URL> resources = actual
+              .getResources("META-INF/services/" + factoryId);
 
             while (resources.hasMoreElements()) {
-                services.addAll(parse(resources.nextElement(), classLoader, LOGGER));
+                services.addAll(parse(resources.nextElement(), actual, LOGGER));
             }
         } catch (IOException e) {
             LOGGER.severe(e);

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceLoader.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceLoader.java
@@ -21,6 +21,26 @@ public final class Target_ServiceLoader {
     @Alias
     private static ILogger LOGGER;
 
+    /**
+     * Hazelcast SPI relies on the classpath presence of multiple _META-INF/services/com.foo.Bar_ files (for example, _com.hazelcast.spi.discovery.multicast.DiscoveryStrategyFactory_).
+     *
+     * However, the internal implementation of ServiceLoader doesn't play along with GraalVM's native images
+     * since Substrate doesn't really feature a _normal_ classpath nor classloading but a mere _simulation_ of these.
+     *
+     * URLs to classpath resources located in different jars normally look like:
+     * ```
+     * jar:file:/work/application/lib/com.hazelcast.hazelcast-4.0.1.jar!/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+     * jar:file:/work/application/lib/com.hazelcast.hazelcast-kubernetes-2.0.1.jar!/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+     * ```
+     *
+     * but under Substrate, they become _resources_ and share the same URL (but `URL#openStream` leads to different content) which requires special handling:
+     * ```
+     * resource:META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+     * resource:META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+     * ```
+     *
+     * In order to make it work under GraalVM, we need to give up extra URL processing and don't enforce uniqueness for URLs, but for their content instead.
+     */
     @Substitute
     private static Set<Target_ServiceDefinition> getServiceDefinitions(String factoryId, ClassLoader classLoader) {
 

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceLoader.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_ServiceLoader.java
@@ -1,0 +1,46 @@
+package io.quarkus.hazelcast.client.runtime.graal;
+
+import com.hazelcast.internal.util.ServiceLoader;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+import static io.quarkus.hazelcast.client.runtime.graal.ServiceLoaderUtils.parse;
+
+@TargetClass(ServiceLoader.class)
+public final class Target_ServiceLoader {
+
+    @Alias
+    private static ILogger LOGGER;
+
+    @Substitute
+    private static Set<Target_ServiceDefinition> getServiceDefinitions(String factoryId, ClassLoader classLoader) {
+
+        Set<Target_ServiceDefinition> services = new HashSet<>();
+
+        try {
+            Enumeration<URL> resources = classLoader.getResources("META-INF/services/" + factoryId);
+
+            while (resources.hasMoreElements()) {
+                services.addAll(parse(resources.nextElement(), classLoader, LOGGER));
+            }
+        } catch (IOException e) {
+            LOGGER.severe(e);
+        }
+
+        if (services.isEmpty()) {
+            Logger.getLogger(ServiceLoader.class).finest(
+              "Service loader could not load 'META-INF/services/" + factoryId + "'. It may be empty or does not exist.");
+        }
+        return services;
+    }
+}
+


### PR DESCRIPTION
This change introduces a GraalVM substitution for `ServiceLoader#getServiceDefinitions` so that discovered classpath resources are properly discovered, read and not accidentally discarded.

### Motivation

Hazelcast SPI relies on the classpath presence of multiple _META-INF/services/com.foo.Bar_ files (for example, _com.hazelcast.spi.discovery.multicast.DiscoveryStrategyFactory_).

The internal implementation of _ServiceLoader_ processes and collects URLs to the classpath resources:

https://github.com/hazelcast/hazelcast/blob/d54fa6df9a88c59f7479744c2b46158f10b2df7f/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java#L101-L124

However, this implementation doesn't play along with GraalVM's native images since Substrate doesn't really feature a _normal_ classpath nor classloading but a mere _simulation_ of these.

URLs to classpath resources located in different jars normally look like:
```
jar:file:/work/application/lib/com.hazelcast.hazelcast-4.0.1.jar!/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
jar:file:/work/application/lib/com.hazelcast.hazelcast-kubernetes-2.0.1.jar!/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
```

but under Substrate, they become _resources_ and share the same URL (but `URL#openStream` leads to different content) which requires special handling:
```
resource:META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
resource:META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
```

So, not only extra processing and conversions are not welcome:
https://github.com/hazelcast/hazelcast/blob/d54fa6df9a88c59f7479744c2b46158f10b2df7f/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java#L109-L112

But also storing URLs in a set causes rejection of valid URLs:
https://github.com/hazelcast/hazelcast/blob/d54fa6df9a88c59f7479744c2b46158f10b2df7f/hazelcast/src/main/java/com/hazelcast/internal/util/ServiceLoader.java#L106


----

fixes https://github.com/hazelcast/quarkus-hazelcast-client/issues/18


