### PR TITLE
Use `ClientConfig.load()` introduced in 4.0.2

### DIFF
--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationResolver.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationResolver.java
@@ -7,7 +7,6 @@ class HazelcastConfigurationResolver {
     private final HazelcastConfigurationParser parser = new HazelcastConfigurationParser();
 
     ClientConfig resolveClientConfig(HazelcastClientConfig properties) {
-        ClientConfig clientConfig = FailoverClientConfigSupport.resolveClientConfig(null);
-        return parser.fromApplicationProperties(properties, clientConfig);
+        return parser.fromApplicationProperties(properties, ClientConfig.load());
     }
 }


### PR DESCRIPTION
Use `ClientConfig.load()` introduced in 4.0.2 instead of `FailoverClientConfigSupport.resolveClientConfig(null)`.