### PR TITLE
Represent member addresses as String and not InetSocketAddress

### DIFF
--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientConfig.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientConfig.java
@@ -1,13 +1,12 @@
 package io.quarkus.hazelcast.client.runtime;
 
-import java.net.InetSocketAddress;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
-
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
 
 @ConfigRoot(name = "hazelcast-client", phase = ConfigPhase.RUN_TIME)
 public class HazelcastClientConfig {

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientConfig.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientConfig.java
@@ -16,7 +16,7 @@ public class HazelcastClientConfig {
      * Hazelcast Cluster members
      */
     @ConfigItem
-    public Optional<List<InetSocketAddress>> clusterMembers;
+    public Optional<List<String>> clusterMembers;
 
     /**
      * Hazelcast client labels

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationParser.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationParser.java
@@ -1,7 +1,5 @@
 package io.quarkus.hazelcast.client.runtime;
 
-import java.net.InetSocketAddress;
-
 import com.hazelcast.client.config.ClientConfig;
 
 class HazelcastConfigurationParser {
@@ -24,6 +22,10 @@ class HazelcastConfigurationParser {
                 clientConfig.getNetworkConfig().addAddress(clusterMember);
             }
         }
+    }
+
+    private void setClusterName(ClientConfig clientConfig, HazelcastClientConfig config) {
+        config.clusterName.ifPresent(clientConfig::setClusterName);
     }
 
     private void setLabels(ClientConfig clientConfig, HazelcastClientConfig config) {

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationParser.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationParser.java
@@ -12,7 +12,6 @@ class HazelcastConfigurationParser {
         setOutboundPorts(clientConfig, config);
         setOutboundPortDefinitions(clientConfig, config);
 
-
         setConnectionTimeout(clientConfig, config);
 
         return clientConfig;

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationParser.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationParser.java
@@ -5,11 +5,13 @@ import com.hazelcast.client.config.ClientConfig;
 class HazelcastConfigurationParser {
 
     ClientConfig fromApplicationProperties(HazelcastClientConfig config, ClientConfig clientConfig) {
+        setClusterName(clientConfig, config);
         setClusterAddress(clientConfig, config);
         setLabels(clientConfig, config);
 
         setOutboundPorts(clientConfig, config);
         setOutboundPortDefinitions(clientConfig, config);
+
 
         setConnectionTimeout(clientConfig, config);
 

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationParser.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationParser.java
@@ -20,8 +20,8 @@ class HazelcastConfigurationParser {
 
     private void setClusterAddress(ClientConfig clientConfig, HazelcastClientConfig config) {
         if (config.clusterMembers.isPresent()) {
-            for (InetSocketAddress clusterMember : config.clusterMembers.get()) {
-                clientConfig.getNetworkConfig().addAddress(clusterMember.toString());
+            for (String clusterMember : config.clusterMembers.get()) {
+                clientConfig.getNetworkConfig().addAddress(clusterMember);
             }
         }
     }


### PR DESCRIPTION
Quarkus' `InetSocketAddressConverter` defaults a port number to 0 which ruins the autodiscovery feature of Hazelcast Client hence it's better to treat member addresses as Strings and it directly to Hazelcast configuration parser.

https://github.com/quarkusio/quarkus/blob/c76ecfc0bb34112de0c7c6e3737056dc843e4b17/core/runtime/src/main/java/io/quarkus/runtime/configuration/InetSocketAddressConverter.java#L37

The change it backward compatible since it's an internal change.

Also, adding a missing `setClusterName()` method.

---- 

Fixes: https://github.com/hazelcast/quarkus-hazelcast-client/issues/55
Fixes: https://github.com/hazelcast/quarkus-hazelcast-client/issues/54