### PR TITLE
Remove quarkus.hazelcast-client.cluster-name from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ By default, client will try to connect to a Hazelcast instance running on the ho
 
 Defaults can be customized using `application.properties` entries such as:
 
-    quarkus.hazelcast-client.cluster-name
     quarkus.hazelcast-client.cluster-members
     quarkus.hazelcast-client.outbound-port-definitions
     quarkus.hazelcast-client.outbound-ports


### PR DESCRIPTION
Until this gets released: https://github.com/hazelcast/quarkus-hazelcast-client/pull/53