### PR TITLE
JmxPublisher#shutdown handling under GraalVM

### DIFF
--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_JmxPublisher.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_JmxPublisher.java
@@ -1,0 +1,53 @@
+package io.quarkus.hazelcast.client.runtime.graal;
+
+import com.hazelcast.internal.metrics.jmx.JmxPublisher;
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import java.util.Set;
+
+@TargetClass(JmxPublisher.class)
+public final class Target_JmxPublisher {
+
+    @Alias
+    private volatile boolean isShutdown;
+
+    @Alias
+    private String domainPrefix;
+
+    @Alias
+    private MBeanServer platformMBeanServer;
+
+    @Alias
+    private String instanceNameEscaped;
+
+    @Substitute
+    public void shutdown() {
+        isShutdown = true;
+        try {
+            // unregister the MBeans registered by this JmxPublisher
+            // the mBeans map can't be used since it is not thread-safe
+            // and is meant to be used by the publisher thread only
+            ObjectName name = new ObjectName(domainPrefix + "*" + ":instance=" + instanceNameEscaped + ",type=Metrics,*");
+            if (platformMBeanServer == null) {
+                return;
+            }
+            Set<ObjectName> objectNames = platformMBeanServer.queryNames(name, null);
+            for (ObjectName bean : objectNames) {
+                unregisterMBeanIgnoreError(bean);
+            }
+        } catch (MalformedObjectNameException e) {
+            throw new RuntimeException("Exception when unregistering JMX beans", e);
+        }
+    }
+
+    @Alias
+    private void unregisterMBeanIgnoreError(ObjectName objectName) {
+    }
+}


### PR DESCRIPTION
Preparing a suitable substitution for `JmxPublisher` since `ManagementFactory.getPlatformMBeanServer();` gets resolved to `null` under GraalVM.

----

Fixes https://github.com/hazelcast/quarkus-hazelcast-client/issues/66