### PR TITLE
Deregister unused reflectively-created classes

### DIFF
--- a/deployment/src/main/java/io/quarkus/hazelcast/client/deployment/HazelcastClientProcessor.java
+++ b/deployment/src/main/java/io/quarkus/hazelcast/client/deployment/HazelcastClientProcessor.java
@@ -98,11 +98,7 @@ class HazelcastClientProcessor {
 
     @BuildStep
     void registerReflectivelyCreatedClasses(BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
-        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false,
-                HazelcastClientCachingProvider.class,
-                DomConfigHelper.class,
-                EventJournalConfig.class,
-                MerkleTreeConfig.class));
+        reflectiveClasses.produce(new ReflectiveClassBuildItem(false, false, HazelcastClientCachingProvider.class));
     }
 
     @BuildStep


### PR DESCRIPTION
Some classes, that are marked as reflectively-created, are actually redundant and can be removed and unburden GraalVM from processing them.