### PR TITLE
Replace MethodHandles with raw reflection in AbstractInvocationFuture

### DIFF
--- a/integration-tests/src/main/java/io/quarkus/it/hazelcast/client/RootResource.java
+++ b/integration-tests/src/main/java/io/quarkus/it/hazelcast/client/RootResource.java
@@ -1,6 +1,7 @@
 package io.quarkus.it.hazelcast.client;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.IAtomicLong;
 import org.jboss.resteasy.annotations.jaxrs.QueryParam;
 
 import javax.ws.rs.GET;
@@ -67,5 +68,13 @@ public class RootResource {
     public String ptable_put_get(@QueryParam("key") String key) {
         return hazelcastInstance.<String, PortableWrapper>getMap("ptable_map")
           .getOrDefault(key, new PortableWrapper("default")).getValue();
+    }
+
+    @GET
+    @Path("/cp/atomic-long/increment")
+    @Produces(MediaType.APPLICATION_JSON)
+    public String cp_atomic_long(@QueryParam("name") String name) {
+        IAtomicLong atomicLong = hazelcastInstance.getCPSubsystem().getAtomicLong(name);
+        return Long.toString(atomicLong.incrementAndGet());
     }
 }

--- a/integration-tests/src/test/java/io/quarkus/it/hazelcast/client/HazelcastClientFunctionalityTest.java
+++ b/integration-tests/src/test/java/io/quarkus/it/hazelcast/client/HazelcastClientFunctionalityTest.java
@@ -52,4 +52,15 @@ public class HazelcastClientFunctionalityTest {
                 .when().get("/hazelcast-client/ptable/get?key=foo")
                 .then().body(is("foo_value"));
     }
+
+    @Test
+    public void shouldIncrementAtomicLong() {
+        RestAssured
+          .when().get("/hazelcast-client/cp/atomic-long/increment?name=foo")
+          .then().body(is("1"));
+
+        RestAssured
+          .when().get("/hazelcast-client/cp/atomic-long/increment?name=foo")
+          .then().body(is("2"));
+    }
 }

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_AbstractInvocationFuture.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/graal/Target_AbstractInvocationFuture.java
@@ -1,0 +1,33 @@
+package io.quarkus.hazelcast.client.runtime.graal;
+
+import com.hazelcast.spi.impl.AbstractInvocationFuture;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(AbstractInvocationFuture.class)
+public final class Target_AbstractInvocationFuture {
+
+    @Substitute
+    private static <T extends Throwable> T tryWrapInSameClass(T cause) {
+        Class<? extends Throwable> exceptionClass = cause.getClass();
+
+        try {
+            return (T) exceptionClass.getConstructor(String.class, Throwable.class)
+              .newInstance(cause.getMessage(), cause);
+        } catch (Throwable e) {
+        }
+
+        try {
+            return (T) exceptionClass.getConstructor(Throwable.class).newInstance(cause);
+        } catch (Throwable e) {
+        }
+
+        try {
+            T result = (T) exceptionClass.getConstructor(String.class).newInstance(cause.getMessage());
+            result.initCause(cause);
+            return result;
+        } catch (Throwable e) {
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Replaces `AbstractInvocationFuture` usages of `MethodHandles` with pure reflection.

There should be no difference performance-wise since reflection ends up being statically compiled under GraalVM.

> (...) If the target elements can be resolved, the calls are removed and instead the target elements are embedded in the code. If the target elements cannot be resolved, e.g., a class is not on the classpath or it does not declare a field/method/constructor, then the calls are replaced with a snippet that throws the appropriate exception at run time. The benefits are twofold. First, at run time there are no calls to the Reflection API. Second, GraalVM can employ constant folding and optimize the code further.

source: [link](https://www.graalvm.org/reference-manual/native-image/Reflection/)

original code:
https://github.com/hazelcast/hazelcast/blob/v4.0.3/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java#L1949-L1970

This will need to be revised for Hazelcast 4.1 since the code changed significantly between 4.0.3 and 4.1.

----

fixes: https://github.com/hazelcast/quarkus-hazelcast-client/issues/94