### PR TITLE
Downgrade Quarkus to 1.8.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
 
     <properties>
-        <quarkus.version>1.9.2.Final</quarkus.version>
+        <quarkus.version>1.8.3.Final</quarkus.version>
         <hazelcast.version>4.0.3</hazelcast.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
We can't bump it in a bugfix release which should remain compatible with Quarkus 1.8