### PR TITLE
Fix broken build

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Checkout repo


### PR DESCRIPTION
`distribution` param is now obligatory