### PR TITLE
remove quarkus-test-artemis

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -56,11 +56,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-test-artemis</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
It was unused, not sure how it got there. Copy-paste most likely.