### PR TITLE
Release only the main artifacts in GH release

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -49,5 +49,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           append_body: true
-          files: '**/target/quarkus-hazelcast-client-*.jar'
+          files: '**/target/quarkus-hazelcast-client-${{ env.VERSION }}*.jar'
           name: "${{ env.VERSION }}"


### PR DESCRIPTION
We shouldn't release jars with tests:
```
👩‍🏭 Creating new GitHub release for tag v4.0.0...
⬆️ Uploading quarkus-hazelcast-client-deployment-4.0.0-javadoc.jar...
⬆️ Uploading quarkus-hazelcast-client-deployment-4.0.0-sources.jar...
⬆️ Uploading quarkus-hazelcast-client-deployment-4.0.0.jar...
⬆️ Uploading quarkus-hazelcast-client-integration-tests-4.0.0-javadoc.jar...
⬆️ Uploading quarkus-hazelcast-client-integration-tests-4.0.0-sources.jar...
⬆️ Uploading quarkus-hazelcast-client-integration-tests-4.0.0-tests.jar...
⬆️ Uploading quarkus-hazelcast-client-integration-tests-4.0.0.jar...
⬆️ Uploading quarkus-hazelcast-client-4.0.0-javadoc.jar...
⬆️ Uploading quarkus-hazelcast-client-4.0.0-sources.jar...
⬆️ Uploading quarkus-hazelcast-client-4.0.0.jar...
```