### PR TITLE
Ref #375: Delay the init of ICMPHelper on non Linux OS

### DIFF
--- a/deployment/src/main/java/io/quarkus/hazelcast/client/deployment/HazelcastClientProcessor.java
+++ b/deployment/src/main/java/io/quarkus/hazelcast/client/deployment/HazelcastClientProcessor.java
@@ -69,6 +69,7 @@ import io.quarkus.deployment.util.ServiceUtil;
 import io.quarkus.hazelcast.client.runtime.HazelcastClientBytecodeRecorder;
 import io.quarkus.hazelcast.client.runtime.HazelcastClientConfig;
 import io.quarkus.hazelcast.client.runtime.HazelcastClientProducer;
+import io.quarkus.utilities.OS;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
 
@@ -232,11 +233,16 @@ class HazelcastClientProcessor {
 
     @BuildStep
     void registerICMPHelper(BuildProducer<NativeImageResourceBuildItem> resources,
+            BuildProducer<RuntimeInitializedClassBuildItem> initializedClasses,
             BuildProducer<RuntimeReinitializedClassBuildItem> reinitializedClasses) {
-        resources.produce(new NativeImageResourceBuildItem(
-                "lib/linux-x86/libicmp_helper.so",
-                "lib/linux-x86_64/libicmp_helper.so"));
-        reinitializedClasses.produce(new RuntimeReinitializedClassBuildItem(ICMPHelper.class.getName()));
+        if (OS.determineOS() == OS.LINUX) {
+            resources.produce(new NativeImageResourceBuildItem(
+                    "lib/linux-x86/libicmp_helper.so",
+                    "lib/linux-x86_64/libicmp_helper.so"));
+            reinitializedClasses.produce(new RuntimeReinitializedClassBuildItem(ICMPHelper.class.getName()));
+        } else {
+            initializedClasses.produce(new RuntimeInitializedClassBuildItem(ICMPHelper.class.getName()));
+        }
     }
 
     @BuildStep


### PR DESCRIPTION
fixes #375 

## Motivation

The compilation fails on Mac OS due to the initialization of the class `ICMPHelper`.

## Modifications:

* Delays the initialization of `ICMPHelper` on non-Linux OS

## Result

The native image can be built on MacOS and the hazelcast client can be used properly as long as the ICM is not needed like in JVM mode