### PR TITLE
Migrate from legacy config classes #415

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
 
     steps:
       - uses: actions/checkout@v4
@@ -39,8 +39,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '11' ]
-        graal: [ '22.3' ]
+        java: [ '21' ]
+        graal: [ '23.1' ]
         hazelcast: [ '5.0.4', '5.1.5', '5.2.3' ]
 
     steps:
@@ -58,10 +58,10 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Pull Quarkus Native Builder Image ${{ matrix.graal }}-java${{ matrix.java }}
-        run: docker pull quay.io/quarkus/ubi-quarkus-native-image:${{ matrix.graal }}-java${{ matrix.java }}
+        run: docker pull quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:${{ matrix.graal }}-java${{ matrix.java }}
 
       - name: Build against ${{ matrix.hazelcast }} on GraalVM ${{ matrix.graal }} 
-        run: ./mvnw -B -Dhazelcast.version=${{ matrix.hazelcast }} verify -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-native-image:${{ matrix.graal }}-java${{ matrix.java }}
+        run: ./mvnw -B -Dhazelcast.version=${{ matrix.hazelcast }} verify -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:${{ matrix.graal }}-java${{ matrix.java }}
 
   build-graalvm-default:
     needs: build-jvm
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/deployment/src/main/java/io/quarkus/hazelcast/client/deployment/HazelcastClientProcessor.java
+++ b/deployment/src/main/java/io/quarkus/hazelcast/client/deployment/HazelcastClientProcessor.java
@@ -1,6 +1,5 @@
 package io.quarkus.hazelcast.client.deployment;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.config.ClientFlakeIdGeneratorConfig;
 import com.hazelcast.client.config.ClientReliableTopicConfig;
@@ -94,7 +93,6 @@ class HazelcastClientProcessor {
                                   BuildProducer<NativeImageResourceBuildItem> resources) throws IOException {
         registerServiceProviders(DiscoveryStrategyFactory.class, resources, reflectiveClasses, generatedResources);
         registerServiceProviders(ClientExtension.class, resources, reflectiveClasses, generatedResources);
-        registerServiceProviders(JsonFactory.class, resources, reflectiveClasses, generatedResources);
     }
 
     @BuildStep
@@ -104,9 +102,8 @@ class HazelcastClientProcessor {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    HazelcastClientConfiguredBuildItem resolveClientProperties(HazelcastClientBytecodeRecorder recorder,
-            HazelcastClientConfig config) {
-        recorder.configureRuntimeProperties(config);
+    HazelcastClientConfiguredBuildItem resolveClientProperties(HazelcastClientBytecodeRecorder recorder) {
+        recorder.configureRuntimeProperties();
         return new HazelcastClientConfiguredBuildItem();
     }
 
@@ -275,7 +272,7 @@ class HazelcastClientProcessor {
             DotName simpleName = DotName.createSimple(klass.getName());
 
             reflectiveHierarchyClass.produce(
-              new ReflectiveHierarchyBuildItem.Builder().type(Type.create(simpleName, Type.Kind.CLASS)).build());
+              ReflectiveHierarchyBuildItem.builder(Type.create(simpleName, Type.Kind.CLASS)).build());
 
             ignoreWarnings.produce(
               new ReflectiveHierarchyIgnoreWarningBuildItem(simpleName));

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
 
     <properties>
-        <quarkus.version>3.2.3.Final</quarkus.version>
+        <quarkus.version>3.25.0</quarkus.version>
         <hazelcast.version>5.2.4</hazelcast.version>
         <jcache.version>1.1.1</jcache.version>
         <affinity.version>3.23.3</affinity.version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -56,14 +56,15 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
 
-      <dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jaxb</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientBytecodeRecorder.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientBytecodeRecorder.java
@@ -1,13 +1,19 @@
 package io.quarkus.hazelcast.client.runtime;
 
 import io.quarkus.arc.Arc;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
 public class HazelcastClientBytecodeRecorder {
+    private final RuntimeValue<HazelcastClientConfig> hazelcastClientConfig;
 
-    public void configureRuntimeProperties(HazelcastClientConfig config) {
+    public HazelcastClientBytecodeRecorder(RuntimeValue<HazelcastClientConfig> hazelcastClientConfig) {
+        this.hazelcastClientConfig = hazelcastClientConfig;
+    }
+
+    public void configureRuntimeProperties() {
         HazelcastClientProducer producer = Arc.container().instance(HazelcastClientProducer.class).get();
-        producer.injectConfig(config);
+        producer.injectConfig(hazelcastClientConfig.getValue());
     }
 }

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientConfig.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastClientConfig.java
@@ -1,49 +1,44 @@
 package io.quarkus.hazelcast.client.runtime;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-@ConfigRoot(name = "hazelcast-client", phase = ConfigPhase.RUN_TIME)
-public class HazelcastClientConfig {
+@ConfigMapping(prefix = "quarkus.hazelcast-client")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface HazelcastClientConfig {
 
     /**
      * Hazelcast Cluster members
      */
-    @ConfigItem
-    public Optional<List<String>> clusterMembers;
+    Optional<List<String>> clusterMembers();
 
     /**
      * Hazelcast client labels
      */
-    @ConfigItem
-    public Optional<List<String>> labels;
+    Optional<List<String>> labels();
 
     /**
      * Hazelcast Cluster group name
      */
-    @ConfigItem
-    public Optional<String> clusterName;
+    Optional<String> clusterName();
 
     /**
      * Outbound ports
      */
-    @ConfigItem
-    public Optional<List<Integer>> outboundPorts;
+    Optional<List<Integer>> outboundPorts();
 
     /**
      * Outbound port definitions
      */
-    @ConfigItem
-    public Optional<List<String>> outboundPortDefinitions;
+    Optional<List<String>> outboundPortDefinitions();
 
     /**
      * Connection timeout
      */
-    @ConfigItem
-    public OptionalInt connectionTimeout;
+    OptionalInt connectionTimeout();
 }

--- a/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationParser.java
+++ b/runtime/src/main/java/io/quarkus/hazelcast/client/runtime/HazelcastConfigurationParser.java
@@ -18,43 +18,43 @@ class HazelcastConfigurationParser {
     }
 
     private void setClusterAddress(ClientConfig clientConfig, HazelcastClientConfig config) {
-        if (config.clusterMembers.isPresent()) {
-            for (String clusterMember : config.clusterMembers.get()) {
+        if (config.clusterMembers().isPresent()) {
+            for (String clusterMember : config.clusterMembers().get()) {
                 clientConfig.getNetworkConfig().addAddress(clusterMember);
             }
         }
     }
 
     private void setClusterName(ClientConfig clientConfig, HazelcastClientConfig config) {
-        config.clusterName.ifPresent(clientConfig::setClusterName);
+        config.clusterName().ifPresent(clientConfig::setClusterName);
     }
 
     private void setLabels(ClientConfig clientConfig, HazelcastClientConfig config) {
-        if (config.labels.isPresent()) {
-            for (String label : config.labels.get()) {
+        if (config.labels().isPresent()) {
+            for (String label : config.labels().get()) {
                 clientConfig.addLabel(label);
             }
         }
     }
 
     private void setConnectionTimeout(ClientConfig clientConfig, HazelcastClientConfig config) {
-        if (config.connectionTimeout.isPresent()) {
-            int timeout = config.connectionTimeout.getAsInt();
+        if (config.connectionTimeout().isPresent()) {
+            int timeout = config.connectionTimeout().getAsInt();
             clientConfig.getNetworkConfig().setConnectionTimeout(timeout);
         }
     }
 
     private void setOutboundPortDefinitions(ClientConfig clientConfig, HazelcastClientConfig config) {
-        if (config.outboundPortDefinitions.isPresent()) {
-            for (String outboundPortDefinition : config.outboundPortDefinitions.get()) {
+        if (config.outboundPortDefinitions().isPresent()) {
+            for (String outboundPortDefinition : config.outboundPortDefinitions().get()) {
                 clientConfig.getNetworkConfig().addOutboundPortDefinition(outboundPortDefinition);
             }
         }
     }
 
     private void setOutboundPorts(ClientConfig clientConfig, HazelcastClientConfig config) {
-        if (config.outboundPorts.isPresent()) {
-            for (Integer outboundPort : config.outboundPorts.get()) {
+        if (config.outboundPorts().isPresent()) {
+            for (Integer outboundPort : config.outboundPorts().get()) {
                 clientConfig.getNetworkConfig().addOutboundPort(outboundPort);
             }
         }


### PR DESCRIPTION
* Upgrades Quarkus to 3.25.0
* Migrates from old org.graalvm.nativeimage:svm to org.graalvm.sdk:graal-sdk
* Migrates HazelcastClientConfig to @ConfigMapping interface
* Cleans up some deprecated Quarkus API usage
* Adapt CI build for Quarkus minimum JDK version (17)

Fixes #415