### PR TITLE
Remove duplicated cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Install JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
@@ -46,17 +40,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Install JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
+          cache: 'maven'
 
       - name: Pull Quarkus Native Builder Image ${{ matrix.graal }}-java${{ matrix.java }}
         run: docker pull quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:${{ matrix.graal }}-java${{ matrix.java }}
@@ -74,17 +63,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: Install JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
+          cache: 'maven'
 
       - name: Build on default GraalVM version
         run: ./mvnw -B verify -Dnative -Dquarkus.native.container-build=true


### PR DESCRIPTION
`build.yml` uses _both_ `actions/cache` and the `actions/setup-java` to cache the Maven repository - only one is required.