### PR TITLE
Replace GitHub pat with `github.token` + `permissions`

### DIFF
--- a/.github/workflows/drafter.yml
+++ b/.github/workflows/drafter.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
We should not require the use of a (long-living) PAT, instead the implicit `github.token` along with the requisite `permissions` should be sufficient.

Unfortunately, as this is in a release-centric action I am unable to test this change without doing a release.
