### PR TITLE
Update Maven Central badge link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hazelcast Client for Quarkus
 
 <a href="https://github.com/actions/toolkit"><img alt="GitHub Actions status" src="https://github.com/hazelcast/quarkus-hazelcast-client/workflows/CI/badge.svg"></a>
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.hazelcast/quarkus-hazelcast-client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.hazelcast/quarkus-hazelcast-client) 
+[![Maven Central](https://maven-badges.sml.io/maven-central/com.hazelcast/quarkus-hazelcast-client/badge.svg)](https://maven-badges.sml.io/maven-central/com.hazelcast/quarkus-hazelcast-client) 
 
 [Hazelcast IMDG](https://hazelcast.com/products/imdg/) is a distributed in-memory object store and compute engine that supports a wide variety of data structures such as Map, Set, List, MultiMap, RingBuffer, HyperLogLog. 
 


### PR DESCRIPTION
The Maven central badge in `README` does not load; the [URL to the badge has changed](https://github.com/softwaremill/maven-badges#a-new-dns-address).

As such, updated.