### PR TITLE
Use centralised `get-supported-maintenance-versions` for Hazelcast compatibility testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,16 +37,16 @@ jobs:
             **/target/**/*.log
             **/target/**/*.txt
   
-   get-hazelcast-versions:
-        runs-on: ubuntu-slim
-        outputs:
-            versions: ${{ steps.versions.outputs.versions }}
-        steps:
-          - id: get-maintenance-versions
-            uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions@master
-          - id: versions
-            run: |
-                echo "versions=$(jq --compact-output 'map(. | tostring + ".0")' <<< '${{ steps.get-maintenance-versions.outputs.versions }}')" >> ${GITHUB_OUTPUT}
+  get-hazelcast-versions:
+    runs-on: ubuntu-slim
+    outputs:
+      versions: ${{ steps.versions.outputs.versions }}
+    steps:
+      - id: get-maintenance-versions
+        uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions@master
+      - id: versions
+        run: |
+            echo "versions=$(jq --compact-output 'map(. | tostring + ".0")' <<< '${{ steps.get-maintenance-versions.outputs.versions }}')" >> ${GITHUB_OUTPUT}
 
   build-graalvm:
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,17 +36,17 @@ jobs:
           path: |
             **/target/**/*.log
             **/target/**/*.txt
-
- get-hazelcast-versions:
-      runs-on: ubuntu-slim
-      outputs:
-          versions: ${{ steps.versions.outputs.versions }}
-      steps:
-        - id: get-maintenance-versions
-          uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions@master
-        - id: versions
-          run: |
-              echo "versions=$(jq --compact-output 'map(. | tostring + ".0")' <<< '${{ steps.get-maintenance-versions.outputs.versions }}')" >> ${GITHUB_OUTPUT}
+  
+   get-hazelcast-versions:
+        runs-on: ubuntu-slim
+        outputs:
+            versions: ${{ steps.versions.outputs.versions }}
+        steps:
+          - id: get-maintenance-versions
+            uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions@master
+          - id: versions
+            run: |
+                echo "versions=$(jq --compact-output 'map(. | tostring + ".0")' <<< '${{ steps.get-maintenance-versions.outputs.versions }}')" >> ${GITHUB_OUTPUT}
 
   build-graalvm:
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,15 +28,28 @@ jobs:
       - name: Build on JVM
         run: ./mvnw -B verify
 
+  get-hazelcast-versions:
+      runs-on: ubuntu-slim
+      outputs:
+          versions: ${{ steps.versions.outputs.versions }}
+      steps:
+        - id: get-maintenance-versions
+          uses: hazelcast/hazelcast/.github/actions/get-supported-maintenance-versions@master
+        - id: versions
+          run: |
+              echo "versions=$(jq --compact-output 'map(. | tostring + ".0")' <<< '${{ steps.get-maintenance-versions.outputs.versions }}')" >> ${GITHUB_OUTPUT}
+
   build-graalvm:
-    needs: build-jvm
+    needs:
+      - build-jvm
+      - get-hazelcast-versions
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         java: [ '21' ]
         graal: [ '23.1' ]
-        hazelcast: [ '5.0.5', '5.1.7', '5.2.5', '5.3.8', '5.4.0', '5.5.0', '5.6.0' ]
+        hazelcast: ${{ fromJSON(needs.get-hazelcast-versions.outputs.versions) }}
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Replicates https://github.com/hazelcast/hazelcast-spring-session/pull/50 for quarkus.

[Example execution](https://github.com/hazelcast/quarkus-hazelcast-client/actions/runs/26456248995).