### PR TITLE
Stop PR builder running twice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    paths-ignore:
-      - '**.md'
   pull_request:
     paths-ignore:
       - '**.md'


### PR DESCRIPTION
The PR builder is triggered whenever a PR is updated (e.g. a via a push) _and_ explicitly on a push, [leading to duplicated executions](https://github.com/hazelcast/quarkus-hazelcast-client/actions/workflows/build.yml?query=actor%3Adependabot):
<img width="463" height="741" alt="image" src="https://github.com/user-attachments/assets/9d2c2bb9-cf21-40dd-bc74-d93a353e38c3" />

Updated implementation to match PR builders in other projects.